### PR TITLE
Stop checking encoding names

### DIFF
--- a/lib/collmex/request.rb
+++ b/lib/collmex/request.rb
@@ -77,7 +77,7 @@ module Collmex
       # http://www.collmex.de/faq.html#zeichensatz_import
       encoded_body = payload.encode("ISO8859-1", undef: :replace) # Do not blow up on undefined characters in ISO8859-1
       response = @http.request_post(Collmex::Request.uri.request_uri, encoded_body, Collmex::Request.header_attributes)
-      response.body.force_encoding("ISO8859-1") if response.body.encoding.to_s == "ASCII-8BIT"
+      response.body.force_encoding("ISO8859-1") if response.body.encoding == Encoding::BINARY
 
       @raw_response[:string] = response.body.encode("UTF-8")
 


### PR DESCRIPTION
Comparing the names is much less efficient than comparing the instance directly.
    
It may also change in the future: https://bugs.ruby-lang.org/issues/18576